### PR TITLE
Fix: Reference action instead of reusable workflow in step

### DIFF
--- a/.github/workflows/metamask-mobile-build-version.yml
+++ b/.github/workflows/metamask-mobile-build-version.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Build Version Generator
         id: build-version
-        uses: MetaMask/metamask-mobile-build-version/.github/workflows/metamask-mobile-build-version.yml@v0.3.0
+        uses: MetaMask/metamask-mobile-build-version@v0.3.0
         with:
           build-version-table: metamask-mobile-build-version
           build-version-key: metamask-mobile


### PR DESCRIPTION
The reusable workflow was incorrectly referencing itself as a reusable workflow within a step. Reusable workflows can only be called at the job level with jobs.*.uses. Within steps, we need to reference the action (action.yml) instead.

This fixes the error:
'reusable workflows should be referenced at the top-level jobs.*.uses key, not within steps'

Changed line 39 from:
uses: MetaMask/metamask-mobile-build-version/.github/workflows/metamask-mobile-build-version.yml@v0.3.0

To:
uses: MetaMask/metamask-mobile-build-version@v0.3.0

This matches the pattern used in v0.2.0 which worked correctly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fix GitHub Actions workflow to call the action directly in the step rather than a reusable workflow path.
> 
> - **CI (GitHub Actions)**:
>   - Update `Build Version Generator` step in `.github/workflows/metamask-mobile-build-version.yml` to use the action `MetaMask/metamask-mobile-build-version@v0.3.0` instead of referencing a reusable workflow path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bf787fec4c441c70b383e74dca0a155008ed1234. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->